### PR TITLE
Add LG 27UD88-W to list of working monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Download app build:
 * Viseo 230Ws
 * Samsung SMT27A300
 * LG 34UC87M (connection: Thunderbolt)
+* LG 27UD88-W
 
 ###### Non-Working
 


### PR DESCRIPTION
Tested on El Cap connected via mini-displayport to display port cable.